### PR TITLE
Build image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,21 +29,24 @@ jobs:
           name: Tag the image according to Giant Swarm convention
           command:
             docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+  
+      - run:
+          name: Docker login
+          command:
+            echo -n "${QUAY_PASSWORD}" | docker login --username "${QUAY_USERNAME}" --password-stdin "$(echo -n 'quay.io/giantswarm/aws-cni' | cut -d/ -f1)"
 
-workflows:
-  version: 2
-  build-and-push:
-    jobs:
-      - build
-      - architect/push-to-docker:
-          context: "architect"
-          name: "push-to-quay"
-          image: "quay.io/giantswarm/aws-cni"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          requires:
-            - build
-          filters:
-            # Trigger job also on git tag.
-            tags:
-              only: /^v.*/
+      - run:
+          name: Docker push (SHA1 tag)
+          command:
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+      
+      - run:
+          name: Docker push release (only for tagged release based on master)
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ] && [ ! -z "${CIRCLE_TAG}" ]
+            then
+                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+            else
+                echo "Not pushing release tag"
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,10 @@ jobs:
             docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
 
 workflows:
-  my-workflow:
+  version: 2
+  build-and-push:
     jobs:
+      - build
       - architect/push-to-docker:
           context: "architect"
           name: "push-to-quay"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  architect: giantswarm/architect@0.10.1
-
 jobs:
   build:
     machine:
@@ -32,8 +29,8 @@ jobs:
   
       - run:
           name: Docker login
-          command:
-            echo -n "${QUAY_PASSWORD}" | docker login --username "${QUAY_USERNAME}" --password-stdin "$(echo -n 'quay.io/giantswarm/aws-cni' | cut -d/ -f1)"
+          command: |
+            echo -n "${QUAY_PASSWORD}" | docker login --username "${QUAY_USERNAME}" --password-stdin quay.io
 
       - run:
           name: Docker push (SHA1 tag)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,5 +17,4 @@ jobs:
       - run:
           name: Build Docker image
           command:
-            cd amazon-vpc-cni-k8s |
-            make docker
+            cd amazon-vpc-cni-k8s && make docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,41 @@ jobs:
   build:
     machine:
       image: "ubuntu-1604:201903-01"
+    environment:
+
+      # Set this to the upstream version tag to use/build
+      UPSTREAM_TAG: v1.7.0-rc1
+
     steps:
       - checkout
+
       - run:
           name: Clone upstream repository
-          command: |
-            export UPSTREAM_TAG=v1.7.0-rc1
+          command:
             git clone -b $UPSTREAM_TAG --depth 1 https://github.com/aws/amazon-vpc-cni-k8s.git
+
       - run:
           name: Build Docker image
           command:
             cd amazon-vpc-cni-k8s && make docker
+
+      - run:
+          name: Tag the image according to Giant Swarm convention
+          command:
+            docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+
+workflows:
+  my-workflow:
+    jobs:
+      - architect/push-to-docker:
+          context: "architect"
+          name: "push-to-quay"
+          image: "quay.io/giantswarm/aws-cni"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          requires:
+            - build
+          filters:
+            # Trigger job also on git tag.
+            tags:
+              only: /^v.*/

--- a/README.md
+++ b/README.md
@@ -8,22 +8,11 @@
     - Import RELEASE_TOKEN variable from template repository for the builds:
       https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#env-vars
 
-    - Change the badge (with style=shield):
-      https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#badges
-      If this is a private repository token with scope `status` will be needed.
-
-    - Run `devctl replace -i "REPOSITORY_NAME" "$(basename $(git rev-parse --show-toplevel))" *.md`
-      and commit your changes.
-
-    - If the repository is public consider adding godoc badge. This should be
-      the first badge separated with a single space.
-      [![GoDoc](https://godoc.org/github.com/giantswarm/REPOSITORY_NAME?status.svg)](http://godoc.org/github.com/giantswarm/REPOSITORY_NAME)
-
 -->
-
+[![Docker Repository on Quay](https://quay.io/repository/giantswarm/aws-cni/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/aws-cni)
 
 # Build automation for AWS CNI
 
-This repository is used to have reproducible builds of Docker images based on 
+This repository is used to have reproducible builds of Docker images based on
 
 https://github.com/aws/amazon-vpc-cni-k8s

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-<!--
-
-    TODO:
-
-    - Add the project to the CircleCI:
-      https://circleci.com/setup-project/gh/giantswarm/REPOSITORY_NAME
-
-    - Import RELEASE_TOKEN variable from template repository for the builds:
-      https://circleci.com/gh/giantswarm/REPOSITORY_NAME/edit#env-vars
-
--->
 [![Docker Repository on Quay](https://quay.io/repository/giantswarm/aws-cni/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/aws-cni)
 
 # Build automation for AWS CNI
@@ -16,3 +5,14 @@
 This repository is used to have reproducible builds of Docker images based on
 
 https://github.com/aws/amazon-vpc-cni-k8s
+
+## Usage
+
+To build a Docker image for a new release:
+
+1. Create a branch.
+2. Modify the `UPSTREAM_TAG` variable in the `.circleci/config.yml` file. Set it to the release tag of the [upstream repo](https://github.com/aws/amazon-vpc-cni-k8s/releases) which should be used. Push to your branch.
+3. Create a pull request for your branch.
+4. Check the `build` job in CI. As a result, there should be an image tagged with the commit SHA in the registry.
+5. Merge the PR after reviews.
+6. Tag a release. As a result, there should be a Docker image with the release tag in the registry.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10711

This sets up a reproducible way to build the AWS CNI docker image purely in CI.

As the Docker build process is not based on a Dockerfile in the repo's root folder, but instead coming from a subfolder that is cloned during the CI run, we are not using architect here.