### PR TITLE
Add workflow to trigger CI on tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,13 @@ jobs:
             else
                 echo "Not pushing release tag"
             fi
+
+workflows:
+  version: 2
+  build-and-push:
+    jobs:
+      - build:
+          filters:
+            # Trigger job also on git tag.
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
This PR adds the missing config that should trigger a build when a tag is added to the git repo.