### PR TITLE
Set upstream tag to v1.6.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
 
       # Set this to the upstream version tag to use/build
-      UPSTREAM_TAG: v1.7.0-rc1
+      UPSTREAM_TAG: v1.6.3
 
     steps:
       - checkout


### PR DESCRIPTION
When merging and releasing this with tag `v1.6.3`, we will have the v1.6.3 image in our registries.