### PR TITLE
updating aws cni image to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
 
       # Set this to the upstream version tag to use/build
-      UPSTREAM_TAG: v1.7.5
+      UPSTREAM_TAG: v1.7.6
 
     steps:
       - checkout


### PR DESCRIPTION
Changes since v1.7.5

Improvement - Avoid detaching EFA ENIs
Improvement - Add t4g instance type
Improvement - Add p4d.24xlarge instance type
Improvement - Update calico to v3.16.2
Improvement - Update readme on stdout support for plugin log file
Bug - Make p3dn.24xlarge examples more realistic
Bug - Make sure we have space for a trunk ENI
Bug - Update README for DISABLE_TCP_EARLY_DEMUX
Bug - Update p4 instance limits

## Checklist

- [ ] Update changelog in CHANGELOG.md.