### PR TITLE
New aws-cni release v1.7.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
 
       # Set this to the upstream version tag to use/build
-      UPSTREAM_TAG: v1.7.7
+      UPSTREAM_TAG: v1.7.8
 
     steps:
       - checkout


### PR DESCRIPTION
Release Notes:
https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.7.8

## Checklist

- [ ] Update changelog in CHANGELOG.md.