### PR TITLE
bump version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
 
       # Set this to the upstream version tag to use/build
-      UPSTREAM_TAG: v1.7.8
+      UPSTREAM_TAG: v1.7.9
 
     steps:
       - checkout


### PR DESCRIPTION
Changes since v1.7.8:
- Improvement - Adds http timeout to aws sessions
- Improvement - Switch calico to be deployed with the Tigera operator
- Improvement - Update calico to v3.17.1
- Improvement - update plugins to v0.9.0
- Improvement - update github.com/containernetworking/plugins to v0.9.0
- Bug - Fix regex match for getting primary interface
- Bug - Output to stderr when no log file path is passed
- Bug - Fix deletion of hostVeth rule for pods using security group

## Checklist

- [ ] Update changelog in CHANGELOG.md.