### PR TITLE
Nftables image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ jobs:
             docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
 
       - run:
+          name: Create a second variant of the image using nftables instead of iptables legacy.
+          command: |
+            docker build --build-arg srcimage=aws-cni:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 .
+            docker build --build-arg srcimage=aws-cni-init:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 .
+
+      - run:
           name: Docker login
           command: |
             echo -n "${QUAY_PASSWORD}" | docker login --username "${QUAY_USERNAME}" --password-stdin quay.io
@@ -40,6 +46,8 @@ jobs:
           command: |
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1
 
       - run:
           name: Docker push release (only for a tagged release)
@@ -50,13 +58,21 @@ jobs:
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
                 docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
-
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
+            
                 # China
                 echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin registry-intl.cn-shanghai.aliyuncs.com
                 docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
                 docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker tag registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
             else
                 echo "Not pushing release tag"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
       - run:
           name: Create a second variant of the image using nftables instead of iptables legacy.
           command: |
-            docker build --build-arg srcimage=aws-cni:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 .
-            docker build --build-arg srcimage=aws-cni-init:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 .
+            docker build --build-arg srcimage=aws-cni:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables .
+            docker build --build-arg srcimage=aws-cni-init:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables .
 
       - run:
           name: Docker login
@@ -46,8 +46,8 @@ jobs:
           command: |
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables
 
       - run:
           name: Docker push release (only for a tagged release)
@@ -58,10 +58,10 @@ jobs:
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
                 docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
             
                 # China
                 echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin registry-intl.cn-shanghai.aliyuncs.com
@@ -69,10 +69,10 @@ jobs:
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
                 docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_SHA1 registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
-                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
-                docker tag registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_SHA1 registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
-                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init-nftables:$CIRCLE_TAG
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
+                docker tag registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
             else
                 echo "Not pushing release tag"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       - run:
           name: Tag the image according to Giant Swarm convention
           command: |
-            docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
-            docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
+            docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-iptables
+            docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-iptables
 
       - run:
           name: Create a second variant of the image using nftables instead of iptables legacy.
@@ -44,8 +44,8 @@ jobs:
       - run:
           name: Docker push (SHA1 tag)
           command: |
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-iptables
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-iptables
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables
             docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables
 
@@ -54,21 +54,21 @@ jobs:
           command: |
             if [ ! -z "${CIRCLE_TAG}" ] && [ -z "${CIRCLE_BRANCH}" ]
             then
-                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
+                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-nftables:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
             
                 # China
                 echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin registry-intl.cn-shanghai.aliyuncs.com
-                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
-                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
-                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
+                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
+                docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker tag registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
-                docker quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
             
                 # China
                 echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin registry-intl.cn-shanghai.aliyuncs.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
                 docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker tag registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
                 docker push registry-intl.cn-shanghai.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
             else
                 echo "Not pushing release tag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add nftables-based image.
+
 ## [1.10.1] - 2022-01-03
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+ARG srcimage
+
+FROM docker.io/giantswarm/$srcimage
+
+RUN yum update -y && yum install -y iptables-nft && update-alternatives --set iptables /usr/sbin/iptables-nft

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ ARG srcimage
 
 FROM docker.io/giantswarm/$srcimage
 
-RUN yum update -y && yum install -y iptables-nft && update-alternatives --set iptables /usr/sbin/iptables-nft
+RUN yum update -y && yum install -y iptables-nft && update-alternatives --set iptables /usr/sbin/iptables-nft && yum clean all

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/aws-cni/tree/master.svg?style=svg)](https://circleci.com/gh/giantswarm/aws-cni/tree/master)
 [![Docker Repository on Quay](https://quay.io/repository/giantswarm/aws-cni/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/aws-cni)
+[![Docker Repository on Quay](https://quay.io/repository/giantswarm/aws-cni-init/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/aws-cni-init)
 
 # Build automation for AWS CNI
 


### PR DESCRIPTION
Since flatcar move to use nftables in recent releases, we need to make aws-cni use nftables as well otherwise networking is broken.

In order to do so, the only reasonable solution is to build a custom aws-cni image with nftables instead of iptables in it.

The goal of this PR is to produce 2 images for each upstream release, one for iptables, one for nftables, using a suffix:

```
$ docker run --rm -ti --entrypoint iptables docker.io/giantswarm/aws-cni:v1.10.1-nftables  --version
iptables v1.8.4 (nf_tables)
$ docker run --rm -ti --entrypoint iptables docker.io/giantswarm/aws-cni:v1.10.1-iptables  --version
iptables v1.8.4 (legacy)
```

This way, we can have a release CR like this:

```
apiVersion: release.giantswarm.io/v1alpha1
kind: Release
...
spec:
...
  components:
...
  - name: aws-cni
    version: 1.10.1-nftables
...
```    

and be able to choose which netfilter backend to choose.

WDYT?

## Checklist

- [x] Update changelog in CHANGELOG.md.
