### PR TITLE
AWS CNI 1.12.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,8 @@ jobs:
       - run:
           name: Tag the image according to Giant Swarm convention
           command: |
-            docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-iptables
-            docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-iptables
-
-      - run:
-          name: Create a second variant of the image using nftables instead of iptables legacy.
-          command: |
-            docker build --build-arg srcimage=amazon/amazon-k8s-cni:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables .
-            docker build --build-arg srcimage=amazon/amazon-k8s-cni-init:$UPSTREAM_TAG -t quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables .
+            docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
 
       - run:
           name: Docker login
@@ -44,35 +38,25 @@ jobs:
       - run:
           name: Docker push (SHA1 tag)
           command: |
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-iptables
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-iptables
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables
-            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1
 
       - run:
           name: Docker push release (only for a tagged release)
           command: |
             if [ ! -z "${CIRCLE_TAG}" ] && [ -z "${CIRCLE_BRANCH}" ]
             then
-                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
-                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
-                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker push quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
 
                 # China
                 echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin giantswarm-registry.cn-shanghai.cr.aliyuncs.com
-                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
-                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-iptables
-                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
-                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-iptables
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1-nftables giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG-nftables
-                docker tag quay.io/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_SHA1-nftables giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
-                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG-nftables
+                docker tag amazon/amazon-k8s-cni:$UPSTREAM_TAG giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
+                docker tag amazon/amazon-k8s-cni-init:$UPSTREAM_TAG giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
+                docker push giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/$CIRCLE_PROJECT_REPONAME-init:$CIRCLE_TAG
             else
                 echo "Not pushing release tag"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
 
       # Set this to the upstream version tag to use/build
-      UPSTREAM_TAG: v1.11.2
+      UPSTREAM_TAG: v1.12.6
 
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `aws-cni` to version 1.12.6.
+
 ## [1.11.2] - 2022-06-14
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-ARG srcimage
-
-FROM $srcimage
-
-RUN yum update -y && yum install -y iptables-nft && update-alternatives --set iptables /usr/sbin/iptables-nft && yum clean all


### PR DESCRIPTION
Addresses https://github.com/giantswarm/vodafone/issues/625

According to the documentation we do not need to create 2 images anymore, with >v1.12.1 we need to set the ENV depending what we want to use nftables or iptables


>In v1.12.1+, iptables-legacy and iptables-nft are present in the VPC CNI container image. Setting ENABLE_NFTABLES environment variable to true instructs VPC CNI to use iptables-nft. By default, iptables-legacy is used



>ENABLE_NFTABLES (v1.12.1+)
>Type: Boolean as a String

>Default: false

>VPC CNI uses iptables-legacy by default. Setting ENABLE_NFTABLES to true will update VPC CNI to use iptables-nft.

>Note: VPC CNI image contains iptables-legacy and iptables-nft. Switching between them is done via update-alternatives. It is strongly recommended that the iptables mode matches that which is used by the base OS and kube-proxy. Switching modes while pods are running or rules are installed will not trigger reconciliation. It is recommended that rules are manually updated or nodes are drained and cordoned before updating. If reloading node, ensure that previous rules are not set to be persisted.


## Checklist

- [x] Update changelog in CHANGELOG.md.
